### PR TITLE
Fix goal editor textarea attribute typo

### DIFF
--- a/js/goals.js
+++ b/js/goals.js
@@ -30,7 +30,7 @@ export async function loadGoal() {
 
 // Render goal editor UI
 function renderGoalEditor(initialValue = '') {
-  container.innerHTML = '<textarea id="goalInput" rows=4" placeholder="Enter your focus…"></textarea><button id="saveGoalBtn">Save</button>';
+  container.innerHTML = '<textarea id="goalInput" rows="4" placeholder="Enter your focus…"></textarea><button id="saveGoalBtn">Save</button>';
   document.getElementById('goalInput').value = initialValue;
   document.getElementById('saveGoalBtn').addEventListener('click', saveAndDisplay);
   


### PR DESCRIPTION
## Summary
- fix incorrect HTML attribute syntax for textarea in goals editor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68464f6daeac832184739df8ed595fd5