### PR TITLE
Fix FART acronym comment

### DIFF
--- a/js/theme-loader.js
+++ b/js/theme-loader.js
@@ -1,7 +1,7 @@
 /**
  * Initial theme loader for Flow app
  * This script loads the user's preferred theme immediately before the page renders
- * to avoid Flash of inAccurate coloR Theme (FART)
+ * to avoid Flash of inaccurate color theme (FART)
  */
 (function() {
   try {


### PR DESCRIPTION
## Summary
- update theme-loader comment for the FART acronym

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846544e733483218bcb864e86e6db37