### PR TITLE
Add CI workflow for PR testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npx cypress install
+      - run: npm run test:unit
+      - run: npm run test:e2e:run
+
+  deploy-preview:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - name: Prepare site
+        run: |
+          mkdir dist
+          rsync -av --exclude='node_modules' --exclude='.git' --exclude='cypress' --exclude='tests' --exclude='.github' ./ dist/
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          destination_dir: pr-preview/pr-${{ github.event.number }}
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com
+      - id: preview
+        name: Set preview url
+        run: echo "url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+      - name: Comment PR with preview URL
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            🚀 Preview your changes here: ${{ steps.preview.outputs.url }}


### PR DESCRIPTION
## Summary
- add CI workflow to run unit and e2e tests on PRs
- deploy preview build of each PR to GitHub Pages
- comment PR with a preview URL for reviewers

## Testing
- `npm ci`
- `npm run test:unit` *(fails: Jest coverage thresholds not met)*
- `npm run test:e2e:run` *(fails: Cypress executable not found)*


------
https://chatgpt.com/codex/tasks/task_e_6846540cd0cc8321840cc4792400a56e