### PR TITLE
Add PR preview deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy site
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: '.'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          clean: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,29 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy preview to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: '.'
+          target-folder: pr-${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          clean: false
+      - name: Comment preview URL
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Preview URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: '.'
-          target-folder: pr-${{ github.event.pull_request.number }}
+          target-folder: preview-pr/pr-${{ github.event.pull_request.number }}
           token: ${{ secrets.GITHUB_TOKEN }}
           clean: false
       - name: Comment preview URL
@@ -26,4 +26,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Preview URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
+            Preview URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/preview-pr/pr-${{ github.event.pull_request.number }}/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Flow
+
+Flow is a static web application.
+
+## Pull request previews
+
+Each pull request automatically deploys a preview of the site using GitHub Pages. The workflow comments a URL in the form:
+
+```
+https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-<PR number>/
+```
+
+Visit the link from the pull request comments to view a live preview of the changes.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The site is served from the `gh-pages` branch. Any push to `main` automatically 
 Each pull request automatically deploys a preview of the site using GitHub Pages. The workflow comments a URL in the form:
 
 ```
-https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-<PR number>/
+https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/preview-pr/pr-<PR number>/
 ```
 
 Visit the link from the pull request comments to view a live preview of the changes.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Flow is a static web application.
 
+## Production deployment
+
+The site is served from the `gh-pages` branch. Any push to `main` automatically deploys the latest files to the root of the Pages site.
+
 ## Pull request previews
 
 Each pull request automatically deploys a preview of the site using GitHub Pages. The workflow comments a URL in the form:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that deploys preview to `gh-pages` for each PR
- document preview URL in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68465546ab688321b28e9a0b416e93b3