### PR TITLE
Add main branch deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy site
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: '.'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Preserve existing preview directories
+          clean: false

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,29 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy preview to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: '.'
+          target-folder: preview-pr/pr-${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          clean: false
+      - name: Comment preview URL
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Preview URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/preview-pr/pr-${{ github.event.pull_request.number }}/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,7 @@
 name: Preview Deploy
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Deploy preview to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Flow
+
+Flow is a static web application.
+
+## Production deployment
+
+The site is served from the `gh-pages` branch. Any push to `main` automatically deploys the latest files to the root of the Pages site.
+Deployments keep the existing `preview-pr` folders so pull request previews remain available.
+
+## Pull request previews
+
+Each pull request automatically deploys a preview of the site using GitHub Pages. The workflow comments a URL in the form:
+
+```
+https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/preview-pr/pr-<PR number>/
+```
+
+Visit the link from the pull request comments to view a live preview of the changes.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ https://${{ github.repository_owner }}.github.io/${{ github.event.repository.nam
 ```
 
 Visit the link from the pull request comments to view a live preview of the changes.
+
+The preview workflow runs on `pull_request_target` so that deployments work for contributions from forks.


### PR DESCRIPTION
## Summary
- deploy `main` branch to the root of the `gh-pages` site
- document production deployment in README
- update PR preview workflow path
- prevent deployment from deleting preview directories

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68465546ab688321b28e9a0b416e93b3