### PR TITLE
Fix deploy action removing preview URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,3 +19,5 @@ jobs:
           folder: '.'
           token: ${{ secrets.GITHUB_TOKEN }}
           clean: true
+          clean-exclude: |
+            preview-pr


### PR DESCRIPTION
## Summary
- ensure preview subdirectory isn't cleaned up when deploying to production

## Testing
- `pre-commit` *(fails: no pre-commit setup)*

------
https://chatgpt.com/codex/tasks/task_e_68465ce80af48321ae945dab1646aaa3