### PR TITLE
Add starter quick-start timer control

### DIFF
--- a/css/timer.css
+++ b/css/timer.css
@@ -37,6 +37,7 @@
   display: flex;
   justify-content: center;
   gap: 12px;
+  flex-wrap: wrap;
   margin-bottom: 16px;
 }
 
@@ -61,6 +62,25 @@
 #addTimeBtn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+#starterBtn {
+  padding: 6px 10px;
+  font-size: 0.85rem;
+  border: 1px dashed var(--muted);
+  background: transparent;
+  color: var(--muted);
+  transition: color var(--transition), border-color var(--transition), transform var(--transition);
+}
+
+#starterBtn:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+#starterBtn:active:not(:disabled) {
+  transform: translateY(0);
 }
 
 /* Sound notification control styles */

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
       <div id="timer">52:00</div>
       <div class="controls">
         <button id="starterBtn" class="secondary">Start with 5</button>
-        <button id="startBtn">Lock In</button>
+        <button id="startBtn">Start</button>
         <button id="pauseBtn">Pause</button>
         <button id="addTimeBtn" title="Add 5 minutes to current session">+5 min</button>
         <button id="endBtn">End</button>

--- a/index.html
+++ b/index.html
@@ -186,6 +186,7 @@
       <div id="timerLabel">Focus Time</div>
       <div id="timer">52:00</div>
       <div class="controls">
+        <button id="starterBtn" class="secondary">Start with 5</button>
         <button id="startBtn">Lock In</button>
         <button id="pauseBtn">Pause</button>
         <button id="addTimeBtn" title="Add 5 minutes to current session">+5 min</button>

--- a/js/constants.js
+++ b/js/constants.js
@@ -5,6 +5,7 @@ export const TIMER_PRESETS = {
   default: { name: '52/17 (Recommended)', work: 52 * 60, break: 17 * 60 },
   pomodoro: { name: '25/5 (Pomodoro)', work: 25 * 60, break: 5 * 60 },
   deepWork: { name: '90/20 (Deep Work)', work: 90 * 60, break: 20 * 60 },
+  starter: { name: '5/5 (Starter)', work: 5 * 60, break: 5 * 60 },
   custom: { name: 'Custom', work: 25 * 60, break: 5 * 60 } // Default values for custom preset
 };
 

--- a/js/timer.js
+++ b/js/timer.js
@@ -64,12 +64,13 @@ export function initTimer() {
     endBtn: endBtn,
     resetBtn: resetBtn,
     addTimeBtn: addTimeBtn,
+    starterBtn: starterBtn,
     timerLabel: document.getElementById('timerLabel')
   });
 
   // Handle quick starter session
   starterBtn?.addEventListener('click', () => {
-    if (!timerCore) return;
+    if (!timerCore || timerCore.state.isRunning) return;
 
     pendingPresetRestore = timerCore.state.currentPreset !== 'starter'
       ? timerCore.state.currentPreset

--- a/js/timer.js
+++ b/js/timer.js
@@ -37,8 +37,11 @@ export function initTimer() {
     onSessionEnd: recordSession,
     onBreakEnd: () => {
       if (pendingPresetRestore && timerCore) {
-        updateTimerPresetWithoutInterruption(pendingPresetRestore);
+        const presetToRestore = pendingPresetRestore;
         pendingPresetRestore = null;
+
+        updateTimerPreset(presetToRestore);
+        timerCore.start();
       }
     },
     getTodos: getTodos,

--- a/js/timerCore.js
+++ b/js/timerCore.js
@@ -399,14 +399,24 @@ export class TimerCore {
           this.endBreak();
         } else {
           // Work session ended
+          // Mark timer as stopped before running callbacks or scheduling next steps
+          this.state.isRunning = false;
+
           if (this.callbacks.onSessionEnd) {
             const sessionDuration = this.state.workDuration;
-            this.callbacks.onSessionEnd({
+            const sessionResult = this.callbacks.onSessionEnd({
               startTime: this.state.startTime,
               duration: sessionDuration,
               isBreak: false,
               todos: this.callbacks.getTodos ? this.callbacks.getTodos() : []
             });
+
+            // Allow consumer to skip break flow after a session
+            if (sessionResult && sessionResult.skipBreak) {
+              this.updateControls(false);
+              this.saveState();
+              return;
+            }
           }
           playSound(getEndSound());
           this.startBreak();

--- a/js/timerCore.js
+++ b/js/timerCore.js
@@ -192,6 +192,10 @@ export class TimerCore {
     
     this.state.isRunning = running;
     
+    if (this.elements.starterBtn) {
+      this.elements.starterBtn.disabled = running;
+    }
+
     if (this.state.onBreak) {
       if (this.elements.startBtn) {
         this.elements.startBtn.disabled = running;
@@ -221,7 +225,7 @@ export class TimerCore {
     } else {
       if (this.elements.startBtn) {
         this.elements.startBtn.disabled = running;
-        this.elements.startBtn.textContent = "Lock In";
+        this.elements.startBtn.textContent = "Start";
       }
       
       if (this.elements.pauseBtn) {


### PR DESCRIPTION
## Summary
- add a Start with 5 control to the timer card and align it with existing buttons
- introduce a 5/5 starter preset and quick-start handler that can restore the prior preset after the session
- update timer title handling for the new preset

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b9c7aa048321a7f7ec96b8ca5e4e)